### PR TITLE
Set GUI ignore DPI in order to see all GUI options

### DIFF
--- a/namDHC.ahk
+++ b/namDHC.ahk
@@ -1459,7 +1459,9 @@ createMainGUI()
 {
 	global
 	local idx, key, opt, optName, obj, btn, array := [], ddList := ""
-	
+
+	gui 1:-DPIScale ; hacky workaround to at least get the options crammed in view - for those folks who use higher DPI settings
+
 	gui 1:add, button, 		hidden default h0 w0 y0 y0 geditOutputFolder,		; For output edit field (default button
 	
 	gui 1:add, statusBar


### PR DESCRIPTION
Added a hacky workaround to at least get the options crammed in view - for those folks who use higher DPI settings. Will probably see some text still truncated, but at least the important options won't be inaccessible like they were.

Doesn't seem to mess up normal GUI view for normal DPI settings.